### PR TITLE
fix: add sense data pattern for dual-actuator SAS drives

### DIFF
--- a/sas-spindown.plg
+++ b/sas-spindown.plg
@@ -216,7 +216,7 @@ DEBUG=&debug;
 [ -f &debugfile; ] &amp;&amp; DEBUG=true
 
 # Regex for sense data indicating "spun down" SAS drive
-SAS_SPUNDOWN_SENSE_RE='(standby condition activated|notify \(enable spinup\) required)'
+SAS_SPUNDOWN_SENSE_RE='(standby condition activated|notify \(enable spinup\) required|additional power use not yet granted)'
 
 . &plugindir;/drive_types 2&gt; /dev/null
 

--- a/sas-spindown.plg
+++ b/sas-spindown.plg
@@ -281,6 +281,24 @@ GetCtrlID () {
         sed 's/0x//g'
   )
 }
+
+# Get peer LUNs on the same SCSI target (for dual-actuator drives).
+# Returns block device names (e.g. "sdf sdg") sharing the same H:C:T.
+# Excludes the device passed as $1.
+GetPeerLUNs () {
+  local DEV=${1#'/dev/'}
+  local HCTL=$(ls /sys/block/$DEV/device/scsi_device/ 2&gt;/dev/null)
+  [ -z "$HCTL" ] &amp;&amp; return
+  local HCT="${HCTL%:*}"
+  local PEERS=""
+  for BLK in /sys/block/sd* ; do
+    local BDEV=$(basename $BLK)
+    [ "$BDEV" = "$DEV" ] &amp;&amp; continue
+    local BHCTL=$(ls $BLK/device/scsi_device/ 2&gt;/dev/null)
+    [ "${BHCTL%:*}" = "$HCT" ] &amp;&amp; PEERS="$PEERS $BDEV"
+  done
+  echo $PEERS
+}
 </INLINE>
 </FILE>
 
@@ -352,10 +370,28 @@ case ${2,,} in
       if ! IsExcluded $RDEVNAME ; then
         if IsRotational $RDEVNAME ; then
 
+          # For dual-actuator drives, collect all LUNs on the same SCSI
+          # target so we can spin them down together.  A dual-actuator
+          # drive shares its platters across actuators (LUNs); spinning
+          # down only one LUN leaves the platters turning for the other,
+          # and any I/O to either LUN in the gap wakes the whole drive.
+          SPINDOWN_DEVS="$RDEVNAME"
+          for PEER in $(GetPeerLUNs $RDEVNAME) ; do
+            if IsSAS $PEER &amp;&amp; IsRotational $PEER &amp;&amp; ! IsExcluded $PEER ; then
+              SPINDOWN_DEVS="$SPINDOWN_DEVS /dev/$PEER"
+            fi
+          done
+
           Log "Spinning down device $RDEVNAME"
-          $DEBUG &amp;&amp; Log "debug: $SG_START -rp3 $RDEVNAME"
-          $SG_START -rp3 $RDEVNAME &gt; /dev/null ||
-             RC=1
+          if [ "$SPINDOWN_DEVS" != "$RDEVNAME" ] ; then
+            Log "Dual-actuator drive detected, also spinning down peer LUN(s):${SPINDOWN_DEVS#$RDEVNAME}"
+          fi
+
+          for SDEV in $SPINDOWN_DEVS ; do
+            $DEBUG &amp;&amp; Log "debug: $SG_START -rp3 $SDEV"
+            $SG_START -rp3 $SDEV &gt; /dev/null &amp;
+          done
+          wait || RC=1
 
         fi
 


### PR DESCRIPTION
## Summary

Two fixes for dual-actuator SAS drives (e.g. Seagate MACH.2 / Water Panther OOS14000G):

### 1. Sense data regex fix (commit 1)

These drives return a different sense string when in standby:
```
Sense key: Not Ready
Additional sense: Logical unit not ready, additional power use not yet granted
```

This is not matched by the current `SAS_SPUNDOWN_SENSE_RE` regex, causing `sdspin status` to report drives as active (rc=0) when they are actually in standby. Unraid then re-issues spindown commands every cycle in an endless loop.

**Fix:** Add `"additional power use not yet granted"` to the regex.

### 2. Dual-actuator simultaneous spindown (commit 2)

Dual-actuator drives expose two LUNs on the same SCSI target (one per actuator). The platters are shared, so the drive cannot physically spin down until **both** LUNs are in standby.

Previously, Unraid spins down each LUN independently with a ~27 second gap. During this gap, any I/O to either LUN wakes the whole physical drive, and the second spindown arrives after the first was already woken — creating an endless cycle.

**Fix:** Add `GetPeerLUNs()` that detects other LUNs on the same SCSI target via sysfs (matching `H:C:T` addresses). When spinning down, all peer LUNs are sent the standby command simultaneously (backgrounded with `&` and `wait`). For single-actuator drives, `GetPeerLUNs()` returns empty and behavior is unchanged.

### Additional note for users

These drives may also ship with `STANDBY_Z=0` in the SPC power condition mode page, which must be enabled per-drive:
```bash
sdparm --set=STANDBY_Z=1 --save /dev/sdX
```
Without this, `sg_start --pc=3` is silently ignored by the drive firmware. This is saved to the drive and persists across reboots.

### Environment

- Unraid 7.2.4
- Broadcom/LSI SAS9306-24i (mpt3sas driver)
- OOS14000G drives (Water Panther rebranded Seagate dual-actuator, SAS, 7200rpm, 14TB)
- Plugin v2024.11.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)